### PR TITLE
FIX: Allow non summary fields to be used as grid field export fields

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -216,6 +216,9 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 
         /** @var GridFieldDataColumns|null $gridFieldColumnsComponent */
         $gridFieldColumnsComponent = $gridField->getConfig()->getComponentByType(GridFieldDataColumns::class);
+        $columnsHandled = ($gridFieldColumnsComponent)
+            ? $gridFieldColumnsComponent->getColumnsHandled($gridField)
+            : [];
 
         /** @var DataObject $item */
         foreach ($items->limit(null) as $item) {
@@ -231,7 +234,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
                         }
 
                         $value = $columnHeader($relObj);
-                    } elseif ($gridFieldColumnsComponent) {
+                    } elseif ($gridFieldColumnsComponent && array_key_exists($columnSource, $columnsHandled)) {
                         $value = strip_tags(
                             $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnSource)
                         );


### PR DESCRIPTION
Fixes regression in https://github.com/silverstripe/silverstripe-framework/commit/3d989a6eae979f2671889376179dfdc7085658ac.